### PR TITLE
Save/load prescriptions from disk

### DIFF
--- a/RePlay/Paginator.cs
+++ b/RePlay/Paginator.cs
@@ -15,7 +15,7 @@ namespace RePlay.WrapperActivities
         public Paginator(int itemsPerPage, List<T> itemsList)
         {
             ItemsList = itemsList;
-            TotalNumItems = ItemsList.Count;
+            TotalNumItems = ItemsList.Count + 1; //+1 to account for plus button
             ItemsPerPage = itemsPerPage;
             ItemsRemaining = TotalNumItems % ItemsPerPage;
             LastPage = Math.Max((TotalNumItems - 1) / ItemsPerPage, 0);
@@ -30,6 +30,11 @@ namespace RePlay.WrapperActivities
             for (int i = start; i < Math.Min(start + ItemsPerPage, ItemsList.Count); i++)
             {
                 data.Add(ItemsList[i]);
+            }
+
+            //If this is the last page, add a dummy element for plus button
+            if (ContainsLast(curr)) {
+                data.Add(default(T));
             }
 
             return data;

--- a/RePlay/Prescription/GameManager.cs
+++ b/RePlay/Prescription/GameManager.cs
@@ -44,6 +44,14 @@ namespace RePlay
             return null;
         }
 
+        public string[] GetNames() {
+            string[] names = new string[this.Count];
+            for (int i = 0; i < this.Count; i++) {
+                names[i] = this[i].Name;
+            }
+            return names;
+        }
+
         public void LoadGames(AssetManager assets) {
             using (var reader = new StreamReader(assets.Open("games.txt")))
             {

--- a/RePlay/Prescription/PrescriptionManager.cs
+++ b/RePlay/Prescription/PrescriptionManager.cs
@@ -33,8 +33,9 @@ namespace RePlay
                 string line;
                 while ((line = reader.ReadLine()) != null)
                 {
-                    string[] data = line.Split(' ');
-
+                    Console.WriteLine(line);
+                    string[] data = line.Split(',');
+                    Console.WriteLine(data);
                     string exercise = data[0];
                     RePlayGame game = GameManager.Instance.FindByNamespace(data[1]);
                     string device = data[2];
@@ -49,7 +50,7 @@ namespace RePlay
         public void SavePrescription() {
             using (var writer = new StreamWriter(filePath)) {
                 foreach (Prescription p in this) {
-                    writer.WriteLine(String.Format("{0} {1}", p.Game.AssetNamespace, p.Duration));
+                    writer.WriteLine(String.Format("{0},{1},{2},{3}", p.Exercise, p.Game.AssetNamespace, p.Device, p.Duration));
                 }
             }
         }

--- a/RePlay/Prescription/PrescriptionManager.cs
+++ b/RePlay/Prescription/PrescriptionManager.cs
@@ -33,9 +33,7 @@ namespace RePlay
                 string line;
                 while ((line = reader.ReadLine()) != null)
                 {
-                    Console.WriteLine(line);
                     string[] data = line.Split(',');
-                    Console.WriteLine(data);
                     string exercise = data[0];
                     RePlayGame game = GameManager.Instance.FindByNamespace(data[1]);
                     string device = data[2];

--- a/RePlay/WrapperActivities/AddPrescriptionFragment.cs
+++ b/RePlay/WrapperActivities/AddPrescriptionFragment.cs
@@ -105,16 +105,16 @@ namespace RePlay.WrapperActivities
                                 (int)_timeSpinner.SelectedItem
                             );
                             prescriptionManager.Add(p);
-                            assigned.Insert(assigned.Count - 1, p);
-                            if (assigned.Count % ItemsPerPage == 1)
+                            if (prescriptionManager.Count % ItemsPerPage == 1)
                             {
                                 settingsActivity.ACurrentPage += 1;
                             }
-                            settingsActivity.assigned_paginator = new Paginator<Prescription>(ItemsPerPage, assigned);
+                            settingsActivity.assigned_paginator = new Paginator<Prescription>(ItemsPerPage, prescriptionManager);
                             settingsActivity.AssignedView.Adapter = new CustomPrescriptionsListView(
                                 settingsActivity,
                                 settingsActivity.assigned_paginator.GeneratePage(settingsActivity.ACurrentPage),
                                 settingsActivity.assigned_paginator.ContainsLast(settingsActivity.ACurrentPage));
+                            prescriptionManager.SavePrescription();
                         }
 
                         Dismiss();

--- a/RePlay/WrapperActivities/AddPrescriptionFragment.cs
+++ b/RePlay/WrapperActivities/AddPrescriptionFragment.cs
@@ -53,7 +53,7 @@ namespace RePlay.WrapperActivities
 
                 if (dialogView != null)
                 {
-                    var gamesList = new List<string>() { "Breakout", "Crossy Road", "Handwriting" };
+                    var gamesList = GameManager.Instance.GetNames();
                     var exerciseList = new List<string>() { "Wrist flexion", "Bicep curl", "Thumb press" };
                     var deviceList = new List<string>() { "FitMi", "Knob sensor" };
                     var timeList = new List<int>() { 1, 2, 3 };

--- a/RePlay/WrapperActivities/AddPrescriptionFragment.cs
+++ b/RePlay/WrapperActivities/AddPrescriptionFragment.cs
@@ -105,7 +105,7 @@ namespace RePlay.WrapperActivities
                                 (int)_timeSpinner.SelectedItem
                             );
                             prescriptionManager.Add(p);
-                            if (prescriptionManager.Count % ItemsPerPage == 1)
+                            if ((prescriptionManager.Count+1) % ItemsPerPage == 1) //+1 to account for last dummy element
                             {
                                 settingsActivity.ACurrentPage += 1;
                             }

--- a/RePlay/WrapperActivities/SettingsActivity.cs
+++ b/RePlay/WrapperActivities/SettingsActivity.cs
@@ -19,13 +19,6 @@ namespace RePlay.WrapperActivities
         GridView AssignedView, SavedView;
         ImageButton ALeftButton, ARightButton, SLeftButton, SRightButton;
 
-        static List<Prescription> assigned = new List<Prescription> {
-            new Prescription("Left-to-Right", null, "FitMi", 3), 
-            new Prescription("WristFlexion", null, "FitMi", 3),
-            new Prescription("Bicep Curl", null, "FitMi", 3),
-            new Prescription("Thumb Press", null, "FitMi", 3)
-        };
-
         static List<Prescription> saved = new List<Prescription> {
             new Prescription("Bicep Curl", null, "FitMi", 3),
             new Prescription("Wrist Supination", null, "FitMi", 3),
@@ -35,7 +28,7 @@ namespace RePlay.WrapperActivities
 
         const int ItemsPerPage = 3;
 
-        Paginator<Prescription> assigned_paginator = new Paginator<Prescription>(ItemsPerPage, assigned);
+        Paginator<Prescription> assigned_paginator = new Paginator<Prescription>(ItemsPerPage, PrescriptionManager.Instance);
         Paginator<Prescription> saved_paginator = new Paginator<Prescription>(ItemsPerPage, saved);
 
         int ACurrentPage = 0;


### PR DESCRIPTION
This commit:

1) Makes `AddPrescriptionFragment` load games from `games.txt` rather than a hard-coded list
2) Fixes prescription saving (Note: Whenever you change `PrescriptionManager.LoadPrescription()` you must also update `PrescriptionManager.SavePrescription()` as the save and load formats must match)
3) Modifies `AddPrescriptionFragment` to save the prescription after adding
3) Modifies `SettingsActivity` to load the prescription rather than using a hard-coded list